### PR TITLE
Changes to facilitate AzureML example

### DIFF
--- a/docs/callbacks.rst
+++ b/docs/callbacks.rst
@@ -28,7 +28,7 @@ Implemented Callbacks
 .. autoclass:: TerminateOnNaNCallback
     :show-inheritance:
 
-.. autoclass:: PrintMetricsCallback
+.. autoclass:: LogMetricsCallback
     :show-inheritance:
 
 .. autoclass:: PrintProgressCallback

--- a/docs/callbacks.rst
+++ b/docs/callbacks.rst
@@ -132,6 +132,26 @@ computed using `TorchMetrics <https://torchmetrics.readthedocs.io/en/latest/page
     If you feel that it would be clearer to compute metrics as part of the training loop, this could also be done by
     subclassing the :class:`pytorch_accelerated.trainer.Trainer` as demonstrated in :ref:`trainer_metric_example`.
 
+Example: Create a custom logging callback
+---------------------------------------------
+
+It is recommended that callbacks are used to handle logging, to keep the training loop focused on the ML related code.
+It is easy to create loggers for other platforms by subclassing the :class:`LogMetricsCallback` callback. For example,
+we can create a logger for AzureML (which uses the MLFlow API) as demonstrated below::
+
+    import mlflow
+
+    class AzureMLLoggerCallback(LogMetricsCallback):
+    def __init__(self):
+        mlflow.set_tracking_uri(os.environ['MLFLOW_TRACKING_URI'])
+
+    def on_training_run_start(self, trainer, **kwargs):
+        mlflow.set_tags(trainer.run_config.to_dict())
+
+    def log_metrics(self, trainer, metrics):
+        if trainer.run_config.is_world_process_zero:
+            mlflow.log_metrics(metrics)
+
 Callback handler
 ======================
 

--- a/docs/trainer.rst
+++ b/docs/trainer.rst
@@ -133,7 +133,7 @@ Internal Setup
 ++++++++++++++++++
 
 .. automethod:: Trainer._create_accelerator
-.. automethod:: Trainer._prepare_model_and_dataloaders_for_training
+.. automethod:: Trainer._prepare_model_optimizer_and_dataloaders
 .. automethod:: Trainer._create_run_config
 
 Training run behaviour

--- a/docs/trainer.rst
+++ b/docs/trainer.rst
@@ -132,8 +132,8 @@ Internal Methods
 Internal Setup
 ++++++++++++++++++
 
-.. automethod:: Trainer._prepare_model_and_optimizer
-.. automethod:: Trainer._prepare_dataloaders
+.. automethod:: Trainer._create_accelerator
+.. automethod:: Trainer._prepare_model_and_dataloaders_for_training
 .. automethod:: Trainer._create_run_config
 
 Training run behaviour

--- a/examples/custom_callback_event.py
+++ b/examples/custom_callback_event.py
@@ -19,7 +19,7 @@ from pytorch_accelerated.callbacks import (
     TerminateOnNaNCallback,
     PrintProgressCallback,
     ProgressBarCallback,
-    PrintMetricsCallback,
+    LogMetricsCallback,
 )
 from pytorch_accelerated.trainer import Trainer
 
@@ -73,7 +73,7 @@ def main():
             TerminateOnNaNCallback,
             PrintProgressCallback,
             ProgressBarCallback,
-            PrintMetricsCallback,
+            LogMetricsCallback,
         ),
     )
 

--- a/examples/vision/transfer_learning/hf_pets_cv_example.py
+++ b/examples/vision/transfer_learning/hf_pets_cv_example.py
@@ -36,7 +36,7 @@ from torchvision.transforms import Compose, RandomResizedCrop, Resize, ToTensor
 
 from pytorch_accelerated.callbacks import (
     TerminateOnNaNCallback,
-    PrintMetricsCallback,
+    LogMetricsCallback,
     PrintProgressCallback,
     ProgressBarCallback,
 )
@@ -200,7 +200,7 @@ def training_function(data_dir, config):
             TerminateOnNaNCallback,
             PrintProgressCallback,
             ProgressBarCallback,
-            PrintMetricsCallback,
+            LogMetricsCallback,
         ),
     )
 

--- a/examples/vision/transfer_learning/progressive_resizing.py
+++ b/examples/vision/transfer_learning/progressive_resizing.py
@@ -19,13 +19,14 @@ from torchvision import transforms, datasets
 
 from pytorch_accelerated.callbacks import (
     TerminateOnNaNCallback,
-    PrintMetricsCallback,
+    LogMetricsCallback,
     PrintProgressCallback,
     EarlyStoppingCallback,
     SaveBestModelCallback,
     TrainerCallback,
     ProgressBarCallback,
 )
+
 from pytorch_accelerated.trainer import Trainer, TrainerPlaceholderValues
 
 
@@ -90,7 +91,7 @@ def main(data_dir):
             AccuracyCallback(num_classes=num_classes),
             PrintProgressCallback,
             ProgressBarCallback,
-            PrintMetricsCallback,
+            LogMetricsCallback,
             EarlyStoppingCallback(early_stopping_patience=2),
             SaveBestModelCallback(watch_metric="accuracy", greater_is_better=True),
         ),
@@ -121,7 +122,7 @@ def main(data_dir):
         }
 
         # Here we use placeholders for the number of epochs and number of steps per epoch, so that the
-        # trainer can inject those values later. This is key especially key for the number of update steps
+        # trainer can inject those values later. This is especially key for the number of update steps
         # which will change depending on whether training is distributed or not
         lr_scheduler = partial(
             OneCycleLR,

--- a/pytorch_accelerated/callbacks.py
+++ b/pytorch_accelerated/callbacks.py
@@ -203,6 +203,8 @@ class LogMetricsCallback(TrainerCallback):
 
     Metrics prefixed with 'train' are logged at the end of a training epoch, all other
     metrics are logged after evaluation.
+
+    This can be subclassed to create loggers for different platforms by overriding the :meth:`~LogMetricsCallback.log_metrics` method.
     """
 
     def on_train_epoch_end(self, trainer, **kwargs):

--- a/pytorch_accelerated/callbacks.py
+++ b/pytorch_accelerated/callbacks.py
@@ -196,16 +196,16 @@ class CallbackHandler:
                 continue
 
 
-class PrintMetricsCallback(TrainerCallback):
+class LogMetricsCallback(TrainerCallback):
     """
-    A callback that prints the latest values of any metric which has been updated in
-    the trainer's run history.
+    A callback that logs the latest values of any metric which has been updated in
+    the trainer's run history. By default, this just prints to the command line.
 
-    Metrics prefixed with 'train' are printed at the end of a training epoch, all other
-    metrics are printed after evaluation.
+    Metrics prefixed with 'train' are logged at the end of a training epoch, all other
+    metrics are logged after evaluation.
     """
 
-    def _print_metrics(self, trainer, metric_names):
+    def log_metrics(self, trainer, metric_names):
         for metric_name in metric_names:
             trainer.print(
                 f"\n{metric_name}: {trainer.run_history.get_latest_metric(metric_name)}"
@@ -218,7 +218,7 @@ class PrintMetricsCallback(TrainerCallback):
             if "train" in metric
         ]
 
-        self._print_metrics(trainer, metric_names)
+        self.log_metrics(trainer, metric_names)
 
     def on_eval_epoch_end(self, trainer, **kwargs):
         metric_names = [
@@ -226,7 +226,7 @@ class PrintMetricsCallback(TrainerCallback):
             for metric in trainer.run_history.get_metric_names()
             if "train" not in metric
         ]
-        self._print_metrics(trainer, metric_names)
+        self.log_metrics(trainer, metric_names)
 
 
 class ProgressBarCallback(TrainerCallback):

--- a/pytorch_accelerated/callbacks.py
+++ b/pytorch_accelerated/callbacks.py
@@ -205,12 +205,6 @@ class LogMetricsCallback(TrainerCallback):
     metrics are logged after evaluation.
     """
 
-    def log_metrics(self, trainer, metric_names):
-        for metric_name in metric_names:
-            trainer.print(
-                f"\n{metric_name}: {trainer.run_history.get_latest_metric(metric_name)}"
-            )
-
     def on_train_epoch_end(self, trainer, **kwargs):
         metric_names = [
             metric
@@ -218,7 +212,7 @@ class LogMetricsCallback(TrainerCallback):
             if "train" in metric
         ]
 
-        self.log_metrics(trainer, metric_names)
+        self._log_latest_metrics(trainer, metric_names)
 
     def on_eval_epoch_end(self, trainer, **kwargs):
         metric_names = [
@@ -226,7 +220,21 @@ class LogMetricsCallback(TrainerCallback):
             for metric in trainer.run_history.get_metric_names()
             if "train" not in metric
         ]
-        self.log_metrics(trainer, metric_names)
+        self._log_latest_metrics(trainer, metric_names)
+
+    def _log_latest_metrics(self, trainer, metric_names):
+        latest_metrics = self._get_latest_metrics(trainer, metric_names)
+        self.log_metrics(trainer, latest_metrics)
+
+    def _get_latest_metrics(self, trainer, metric_names):
+        return {
+            metric_name: trainer.run_history.get_latest_metric(metric_name)
+            for metric_name in metric_names
+        }
+
+    def log_metrics(self, trainer, metrics):
+        for metric_name, metric_value in metrics.items():
+            trainer.print(f"\n{metric_name}: {metric_value}")
 
 
 class ProgressBarCallback(TrainerCallback):

--- a/pytorch_accelerated/callbacks.py
+++ b/pytorch_accelerated/callbacks.py
@@ -199,7 +199,7 @@ class CallbackHandler:
 class LogMetricsCallback(TrainerCallback):
     """
     A callback that logs the latest values of any metric which has been updated in
-    the trainer's run history. By default, this just prints to the command line.
+    the trainer's run history. By default, this just prints to the command line once per machine.
 
     Metrics prefixed with 'train' are logged at the end of a training epoch, all other
     metrics are logged after evaluation.
@@ -234,7 +234,7 @@ class LogMetricsCallback(TrainerCallback):
             for metric_name in metric_names
         }
 
-    def log_metrics(self, trainer, metrics):
+    def log_metrics(self, trainer, metrics: dict):
         for metric_name, metric_value in metrics.items():
             trainer.print(f"\n{metric_name}: {metric_value}")
 

--- a/pytorch_accelerated/run_config.py
+++ b/pytorch_accelerated/run_config.py
@@ -1,5 +1,5 @@
 # Copyright © 2021 Chris Hughes
-from dataclasses import dataclass
+from dataclasses import dataclass, asdict
 from numbers import Number
 from typing import Union
 
@@ -43,3 +43,6 @@ class TrainerRunConfig:
     is_world_process_zero: bool
     is_distributed: bool
     using_fp16: bool
+    
+    def to_dict(self):
+        return asdict(self)

--- a/pytorch_accelerated/run_config.py
+++ b/pytorch_accelerated/run_config.py
@@ -43,6 +43,6 @@ class TrainerRunConfig:
     is_world_process_zero: bool
     is_distributed: bool
     using_fp16: bool
-    
+
     def to_dict(self):
         return asdict(self)

--- a/pytorch_accelerated/trainer.py
+++ b/pytorch_accelerated/trainer.py
@@ -740,7 +740,7 @@ class Trainer:
 
     def save_checkpoint(self, save_path, checkpoint_kwargs=None, save_optimizer=True):
         """
-        Save the model, optimizer and specified args as a checkpoint file.
+        Save the model, optimizer and specified args as a checkpoint file. This is done once per machine.
 
         :param save_path: the path where to save the checkpoint, this should end in '.pt'
         :param checkpoint_kwargs: additional objects to include in the checkpoint

--- a/pytorch_accelerated/trainer.py
+++ b/pytorch_accelerated/trainer.py
@@ -398,7 +398,7 @@ class Trainer:
                 batch_size=per_device_batch_size, eval_dl_kwargs=eval_dataloader_kwargs
             )
 
-        self._prepare_model_and_dataloaders_for_training()
+        self._prepare_model_optimizer_and_dataloaders()
 
         self.run_config = self._create_run_config(
             num_epochs=num_epochs,
@@ -440,7 +440,7 @@ class Trainer:
             batch_size=per_device_batch_size, eval_dl_kwargs=dataloader_kwargs
         )
 
-        self._prepare_model_and_dataloaders_for_training()
+        self._prepare_model_optimizer_and_dataloaders()
 
         self._run_evaluation()
 
@@ -490,7 +490,7 @@ class Trainer:
         """
         return self._accelerator.device
 
-    def _prepare_model_and_dataloaders_for_training(self):
+    def _prepare_model_optimizer_and_dataloaders(self):
         """
         Uses the trainer's instance of :class:`accelerate.Accelerator` to wrap the model, optimizer and dataloaders in any wrappers necessary for training.
         (e.g. :class:`torch.nn.parallel.DistributedDataParallel`) and ensures the parameters are placed on the appropriate device.

--- a/pytorch_accelerated/trainer.py
+++ b/pytorch_accelerated/trainer.py
@@ -116,7 +116,7 @@ class Trainer:
         :class:`~pytorch_accelerated.callbacks.TerminateOnNaNCallback`,
         :class:`~pytorch_accelerated.callbacks.PrintProgressCallback`,
         :class:`~pytorch_accelerated.callbacks.ProgressBarCallback`,
-        :class:`~pytorch_accelerated.callbacks.PrintMetricsCallback`,
+        :class:`~pytorch_accelerated.callbacks.LogMetricsCallback`,
         )
 
         """


### PR DESCRIPTION
* Rename PrintMetricsCallback to LogMetricsCallback
* Refactor LogMetricsCallback to make it easier to override the log method
* Add an example of creating a custom logger to the docs
* Refactor accelerator prepare logic so that the model, optimizer and data loaders are passed together. This should enable DeepSpeed integration
* Add serialization method to RunConfig