### PR TITLE
Added an example to the docs for a callback that saves predictions during evaluation

### DIFF
--- a/docs/callbacks.rst
+++ b/docs/callbacks.rst
@@ -175,7 +175,7 @@ Here is an example custom callback to record predictions during evaluation and t
 
         def on_eval_epoch_end(self, trainer, **kwargs):
             trainer._accelerator.wait_for_everyone()
-            if  trainer._accelerator.is_local_main_process:
+            if trainer.run_config.is_local_process_zero:
                 df = pd.DataFrame.from_dict(self.predictions)
                 df.to_csv(f'{self.out_filename}', index=False)
             

--- a/docs/callbacks.rst
+++ b/docs/callbacks.rst
@@ -155,7 +155,7 @@ we can create a logger for AzureML (which uses the MLFlow API) as demonstrated b
 Example: Create a custom callback to save predictions on evaluation
 -------------------------------------------------------------------
 
-Here is an example custom callback to record predictions during evaluation and then save them to csv at the end of the evaluation epoch. 
+Here is an example custom callback to record predictions during evaluation and then save them to csv at the end of the evaluation epoch::
 
     from collections import defaultdict
     import pandas as pd


### PR DESCRIPTION
1. Added an example callback to the doc file to save predictions during evaluation.
2. Added indentation to the functions of the AzureMLLoggerCallback example as the functions were at the same indent as the class keyword.