### PR TITLE
Add limit batches context manager

### DIFF
--- a/pytorch_accelerated/callbacks.py
+++ b/pytorch_accelerated/callbacks.py
@@ -182,9 +182,12 @@ class CallbackHandler:
         cb = callback() if isinstance(callback, type) else callback
         cb_class = callback if isinstance(callback, type) else callback.__class__
         if cb_class in {c.__class__ for c in self.callbacks}:
+
+            existing_callbacks = "\n".join(cb for cb in self.callback_list)
+
             raise ValueError(
                 f"You attempted to add multiple instances of the callback {cb_class} to a single Trainer"
-                f" The list of callbacks already present is\n: {self.callback_list}"
+                f" The list of callbacks already present is\n: {existing_callbacks}"
             )
         self.callbacks.append(cb)
 
@@ -196,7 +199,7 @@ class CallbackHandler:
 
     @property
     def callback_list(self):
-        return "\n".join(cb.__class__.__name__ for cb in self.callbacks)
+        return [cb.__class__.__name__ for cb in self.callbacks]
 
     def call_event(self, event, *args, **kwargs):
         """
@@ -497,6 +500,7 @@ class MoveModulesToDeviceCallback(TrainerCallback):
     def on_evaluation_run_start(self, trainer, **kwargs):
         self._move_modules_to_device(trainer)
 
+
 class DataLoaderSlice:
     def __init__(self, dl, slice_size):
         self.dl = dl
@@ -513,6 +517,7 @@ class LimitBatchesCallback(TrainerCallback):
     """
     A callback that that limits the number of batches used during training and evaluation
     """
+
     def __init__(self, num_batches):
         self.num_batches = num_batches
 

--- a/pytorch_accelerated/utils.py
+++ b/pytorch_accelerated/utils.py
@@ -1,7 +1,47 @@
+import os
 from functools import wraps
 
 from accelerate.state import AcceleratorState
 from accelerate.utils import wait_for_everyone
+
+LIMIT_BATCHES_ENV_VAR = "PT_ACC_LIMIT_BATCHES"
+
+
+class LimitBatches:
+    """
+    A context manager which can be used to limit the batches used within a :class:`~pytorch_accelerated.trainer.Trainer`.
+    Any Trainer initialised within this context manager will contain the :class:`~pytorch_accelerated.callbacks.LimitBatchesCallback`
+    callback. To remove this behaviour, a new trainer must be created or this callback must be explicitly removed.
+    """
+
+    def __init__(self, num_batches: int):
+        self.num_batches = num_batches
+
+    def __enter__(self):
+        os.environ[LIMIT_BATCHES_ENV_VAR] = str(self.num_batches)
+        return self
+
+    def __exit__(self, exc_type, exc_value, exc_traceback):
+        del os.environ[LIMIT_BATCHES_ENV_VAR]
+
+
+def limit_trainer_batches(func, *, num_batches):
+    """
+    A decorator which can be used to ensure that the decorated function is only executed on the local main process
+    during distributed training
+
+    :param func: the function to be decorated
+    """
+
+    @wraps(func)
+    def wrapper_func(*args, **kwargs):
+        os.environ[LIMIT_BATCHES_ENV_VAR] = num_batches
+        result = func(*args, **kwargs)
+        del os.environ[LIMIT_BATCHES_ENV_VAR]
+
+        return result
+
+    return wrapper_func
 
 
 def local_process_zero_only(func):

--- a/test/utils.py
+++ b/test/utils.py
@@ -1,0 +1,26 @@
+from unittest.mock import Mock
+
+from pytorch_accelerated import Trainer
+from pytorch_accelerated.callbacks import LimitBatchesCallback
+from pytorch_accelerated.utils import LimitBatches
+
+
+def test_can_limit_batches_with_manager():
+    limit_batches_num = 4
+    with LimitBatches(limit_batches_num):
+        limited_trainer = Trainer(model=Mock(), loss_func=Mock(), optimizer=Mock())
+    callback = limited_trainer.callback_handler.callbacks[0]
+
+    assert isinstance(callback, LimitBatchesCallback)
+    assert callback.num_batches == limit_batches_num
+
+
+def test_limit_batches_not_present_outside_manager():
+    with LimitBatches(2):
+        pass
+
+    trainer = Trainer(model=Mock(), loss_func=Mock(), optimizer=Mock())
+
+    assert LimitBatchesCallback not in {
+        callback.__class__ for callback in trainer.callback_handler.callbacks
+    }


### PR DESCRIPTION
Add a context manager which can be used to limit the number of training and evaluation batches used without having to manually add the callback. This is done by setting an environment variable.