### PR TITLE
Fix remove_padding for higher dimensionality tensors

### DIFF
--- a/pytorch_accelerated/utils.py
+++ b/pytorch_accelerated/utils.py
@@ -173,9 +173,9 @@ def remove_padding(padded_tensor: Tensor, pad_value):
     """
     padding_mask = padded_tensor == pad_value
 
-    if padding_mask.ndim > 1:
+    while padding_mask.ndim > 1:
         padding_mask = torch.all(padding_mask, dim=-1)
 
-    result = padded_tensor[~padding_mask]
+    result = padded_tensor[~padding_mask, ...]
 
     return result

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -67,6 +67,20 @@ def test_can_remove_padding_3d():
     assert torch.eq(expected_t, actual_t).all()
 
 
+@pytest.mark.parametrize("shape", [(3, 4), (3, 4, 2), (3, 4, 2, 5)])
+def test_can_remove_padding(shape):
+    batch_size, *_ = shape
+
+    t = torch.ones(*shape)
+    t[-1, ...] = PAD_VALUE
+
+    expected_t = torch.ones(batch_size - 1, *shape[1:])
+
+    actual_t = remove_padding(t, PAD_VALUE)
+
+    assert torch.eq(expected_t, actual_t).all()
+
+
 @pytest.mark.parametrize(
     "process_decorator",
     [world_process_zero_only, local_process_zero_only, local_process_zero_first],


### PR DESCRIPTION
The current `remove_padding` functionality was not working for higher dimensionality tensors (`ndim > 2`). In fact, the test for 3D was passing incidentally because the first and second dimensions of the tested tensor were the same.

The `padding_mask` only needs to operate over the batch dimension, which by convention, is the `dim=0`. That means, it always needs to be one-dimensional when applied to the tensor. The current code only reduces one dimension, which means that for higher than 2 dimensions, the mask has more than one dimension, leading to unexpected and often erroneous results.

The PR fixes these issues and adds tests to validate that now the code works. Previous tests are left in to show there is no regression.