### PR TITLE
Improve reporting of issues with batch size on distributed evaluate

### DIFF
--- a/pytorch_accelerated/trainer.py
+++ b/pytorch_accelerated/trainer.py
@@ -4,6 +4,7 @@ import os
 from enum import Enum
 from functools import partial
 from typing import Iterable
+import warnings
 
 import torch
 from accelerate import Accelerator, DistributedType
@@ -673,15 +674,46 @@ class Trainer:
         return TrainerRunConfig(**config)
 
     def _check_eval_batch_size(self):
-        if (
-            self.eval_dataset is not None
-            and self.run_config.eval_total_batch_size > len(self.eval_dataset)
-            and self.run_config.is_distributed
-        ):
+        if self.eval_dataset is None or not self.run_config.is_distributed:
+            return
+
+        if self.run_config.eval_total_batch_size > len(self.eval_dataset):
             raise ValueError(
                 f"The total batch size {self.run_config.eval_total_batch_size} \
                   across all processes is bigger than eval dataset size {len(self.eval_dataset)}. \
                   This can be resolved by lowering the batch size"
+            )
+
+        n_samples_last_batch = (
+            len(self.eval_dataset) % self.run_config.eval_total_batch_size
+        )
+        # Minimum number of samples to ensure all processes have at least one sample
+        min_samples_last_batch = (
+            self.run_config.eval_per_device_batch_size
+            * (self.run_config.num_processes - 1)
+            + 1
+        )
+        if n_samples_last_batch < min_samples_last_batch:
+            raise ValueError(
+                f"The per device batch size {self.run_config.eval_per_device_batch_size} with the "
+                f"eval dataset size {len(self.eval_dataset)} and the number of processes "
+                f"{self.run_config.num_processes} will cause at least one process to have no "
+                "samples on the last batch, which would lead to a `Trainer.gather` to freeze "
+                "indefinitely. This can be resolved by setting a different batch size"
+            )
+
+        if (
+            min_samples_last_batch
+            <= n_samples_last_batch
+            < self.run_config.eval_total_batch_size
+        ):
+            warnings.warn(
+                f"The per device batch size {self.run_config.eval_per_device_batch_size} with the "
+                f"eval dataset size {len(self.eval_dataset)} and the number of processes "
+                f"{self.run_config.num_processes} will cause one process to have a smaller number "
+                "of samples on the last batch than the rest, which would lead to a "
+                "`Trainer.gather` to freeze indefinitely. This can be resolved by passing a "
+                "`padding_value` to the `Trainer.gather`."
             )
 
     def _run_training(self):

--- a/pytorch_accelerated/trainer.py
+++ b/pytorch_accelerated/trainer.py
@@ -694,15 +694,14 @@ class Trainer:
             + 1
         )
         if n_samples_last_batch < min_samples_last_batch:
-            raise ValueError(
+            warnings.warn(
                 f"The per device batch size {self.run_config.eval_per_device_batch_size} with the "
                 f"eval dataset size {len(self.eval_dataset)} and the number of processes "
                 f"{self.run_config.num_processes} will cause at least one process to have no "
                 "samples on the last batch, which would lead to a `Trainer.gather` to freeze "
                 "indefinitely. This can be resolved by setting a different batch size"
             )
-
-        if (
+        elif (
             min_samples_last_batch
             <= n_samples_last_batch
             < self.run_config.eval_total_batch_size

--- a/test/test_trainer.py
+++ b/test/test_trainer.py
@@ -200,7 +200,7 @@ def test_check_eval_batch_size_raises_empty_node_on_last_batch():
     trainer.eval_dataset = list(range(n_samples))
     trainer.run_config = FakeRunConfig()
 
-    with pytest.raises(ValueError):
+    with pytest.warns(UserWarning):
         trainer._check_eval_batch_size()
 
 

--- a/test/test_trainer.py
+++ b/test/test_trainer.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 from tempfile import TemporaryFile, TemporaryDirectory
 from unittest.mock import MagicMock, Mock, call
+import pytest
 
 import torch
 from pytest import fixture
@@ -147,3 +148,81 @@ def test_can_create_scheduler():
 
 def test_can_reset_run_history():
     pass
+
+
+def test_check_eval_batch_size_is_transparent_on_single_process():
+    batch_size = 8
+    n_samples = batch_size - 1
+
+    class FakeRunConfig:
+        eval_total_batch_size = batch_size
+        is_distributed = False
+
+    trainer = Trainer("irrelevant", "irrelevant", "irrelevant")
+    trainer.eval_dataset = list(range(n_samples))
+    trainer.run_config = FakeRunConfig()
+
+    trainer._check_eval_batch_size()
+
+
+def test_check_eval_batch_size_raises_batch_size_bigger_than_dataset():
+    batch_size = 8
+
+    class FakeRunConfig:
+        eval_total_batch_size = batch_size
+        is_distributed = True
+
+    trainer = Trainer("irrelevant", "irrelevant", "irrelevant")
+    trainer.eval_dataset = list(range(batch_size - 1))
+    trainer.run_config = FakeRunConfig()
+
+    with pytest.raises(ValueError):
+        trainer._check_eval_batch_size()
+
+
+def test_check_eval_batch_size_raises_empty_node_on_last_batch():
+    per_device_batch_size = 8
+    n_processes = 4
+    n_full_batches = 2
+
+    n_samples_full_batches = per_device_batch_size * n_processes * n_full_batches
+    # One process will have no samples, another one less samples than the batch size
+    n_samples_last_batch = per_device_batch_size * (n_processes - 1) - 1
+    n_samples = n_samples_full_batches + n_samples_last_batch
+
+    class FakeRunConfig:
+        eval_per_device_batch_size = per_device_batch_size
+        eval_total_batch_size = per_device_batch_size * n_processes
+        num_processes = n_processes
+        is_distributed = True
+
+    trainer = Trainer("irrelevant", "irrelevant", "irrelevant")
+    trainer.eval_dataset = list(range(n_samples))
+    trainer.run_config = FakeRunConfig()
+
+    with pytest.raises(ValueError):
+        trainer._check_eval_batch_size()
+
+
+def test_check_eval_batch_size_warns_padding_is_needed():
+    per_device_batch_size = 8
+    n_processes = 4
+    n_full_batches = 2
+
+    n_samples_full_batches = per_device_batch_size * n_processes * n_full_batches
+    # One process will have just one sample
+    n_samples_last_batch = per_device_batch_size * (n_processes - 1) + 1
+    n_samples = n_samples_full_batches + n_samples_last_batch
+
+    class FakeRunConfig:
+        eval_per_device_batch_size = per_device_batch_size
+        eval_total_batch_size = per_device_batch_size * n_processes
+        num_processes = n_processes
+        is_distributed = True
+
+    trainer = Trainer("irrelevant", "irrelevant", "irrelevant")
+    trainer.eval_dataset = list(range(n_samples))
+    trainer.run_config = FakeRunConfig()
+
+    with pytest.warns(UserWarning):
+        trainer._check_eval_batch_size()


### PR DESCRIPTION
When running a `Trainer.evaluate` on a multi GPU configuration, the interaction between the batch size and the size of the eval dataset may cause either:
1. One process have a different number of samples than the rest on the last batch.
2. One or more processes to have 0 samples on the last batch.

In most (if not all) cases, at some point during or after an evaluate run, there will be a call to `Trainer.gather` to synchronize the results across processes. If any of the 2 conditions is mentioned, that will freeze the run without any kind of reporting, which can be extremely frustrating and hard to debug if the user has not encountered it before.

Number 1. can be solved by ensuring a `padding_value` to `Trainer.gather`. Number 2. can only be solved by setting an appropriate batch size that fixes the issue.

This PR adds a warning for number 1. so that users are prompted to ensure they make the right call and an error raise for number 2. to force the user to pick an adequate batch size.

There is one point open to discussion though:

Users that do not need to gather (because they save the outputs in a distributed fashion or because they do not need to persist the outputs, for instance) will never be hit by these cases. This is ok for number 1, because only a warning is raised. The issue is the way this is defined now, number 2. would enforce users to change to a different batch size (potentially a suboptimal one) for something they do not care about.

Then the question becomes: Do we want to just warn or do we raise an error for case 2? 