### PR TITLE
Fix an undesired warning when all batches are full for all processes

### DIFF
--- a/pytorch_accelerated/trainer.py
+++ b/pytorch_accelerated/trainer.py
@@ -693,7 +693,7 @@ class Trainer:
             * (self.run_config.num_processes - 1)
             + 1
         )
-        if n_samples_last_batch < min_samples_last_batch:
+        if 0 < n_samples_last_batch < min_samples_last_batch:
             warnings.warn(
                 f"The per device batch size {self.run_config.eval_per_device_batch_size} with the "
                 f"eval dataset size {len(self.eval_dataset)} and the number of processes "

--- a/test/test_trainer.py
+++ b/test/test_trainer.py
@@ -165,6 +165,32 @@ def test_check_eval_batch_size_is_transparent_on_single_process():
     trainer._check_eval_batch_size()
 
 
+def test_check_eval_batch_size_is_transparent_with_full_batches_for_all_processes():
+    per_device_batch_size = 8
+    n_processes = 4
+    n_full_batches = 2
+
+    n_samples_full_batches = per_device_batch_size * n_processes * n_full_batches
+    # All batches are exactly full
+    n_samples_last_batch = 0
+    n_samples = n_samples_full_batches + n_samples_last_batch
+
+    class FakeRunConfig:
+        eval_per_device_batch_size = per_device_batch_size
+        eval_total_batch_size = per_device_batch_size * n_processes
+        num_processes = n_processes
+        is_distributed = True
+
+    trainer = Trainer("irrelevant", "irrelevant", "irrelevant")
+    trainer.eval_dataset = list(range(n_samples))
+    trainer.run_config = FakeRunConfig()
+
+    with pytest.warns(None) as record:
+        trainer._check_eval_batch_size()
+
+    assert len(record) == 0
+
+
 def test_check_eval_batch_size_raises_batch_size_bigger_than_dataset():
     batch_size = 8
 


### PR DESCRIPTION
The logic implemented in the previous release was raising a warning erroneously when the batches fit perfectly across processes. This resolves that false warning.