### PR TITLE
Fix run history for evaluate run

### DIFF
--- a/pytorch_accelerated/trainer.py
+++ b/pytorch_accelerated/trainer.py
@@ -499,14 +499,13 @@ class Trainer:
 
         self._prepare_model_optimizer_and_dataloaders()
 
-        if self.run_config is None:
-            self.run_config = self._create_run_config(
-                num_epochs=1,
-                gradient_accumulation_steps=0,
-                max_num_train_steps=None,
-                per_device_batch_size=per_device_batch_size,
-                gradient_clip_value=None,
-            )
+        self.run_config = self._create_run_config(
+            num_epochs=1,
+            gradient_accumulation_steps=1,
+            max_num_train_steps=None,
+            per_device_batch_size=per_device_batch_size,
+            gradient_clip_value=None,
+        )
 
         self._check_eval_batch_size()
 


### PR DESCRIPTION
Previously, when running `evaluate` run, the `RunConfig` of the previous training (if any) would be persisted. That caused that if we used a different batch size for `train` and `evaluate`, the attributes of batch size were wrong (albeit the dataloader was correct). This made the warnings for batch size against test dataset length to be raised on some instances misleadingly.

These changes create a new run config for `evaluate` where the attributes are correct. If a user wants to keep the training run config, they can extract it normally from the `Trainer` prior to running `evaluate`.